### PR TITLE
Lowercase decorator names?

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,26 +32,26 @@ The second setting lets sequelize-decorators infer the type of attributes from t
 
 ```js
 import {Sequelize, Model, DataTypes} from 'sequelize'
-import {Options, Attribute} from 'sequelize-decorators'
+import {options, attribute} from 'sequelize-decorators'
 
 const sequelize = new Sequelize(process.env.DB)
 
-@Options({
+@options({
     sequelize,
     tableName: 'users'
 })
 export class User extends Model {
 
-    @Attribute({
+    @attribute({
         type: DataTypes.STRING,
         primaryKey: true
     })
     public username: string;
 
-    @Attribute(DataTypes.STRING)
+    @attribute(DataTypes.STRING)
     public firstName: string;
 
-    @Attribute() // Type is inferred as DataTypes.STRING
+    @attribute() // Type is inferred as DataTypes.STRING
     public lastName: string;
 
     get fullName(): string {
@@ -66,7 +66,7 @@ export class User extends Model {
 }
 ```
 
-The `@Options` decorator is required and must include the `sequelize` option (the connection to use).
+The `@options` decorator is required and must include the `sequelize` option (the connection to use).
 
 ### Type inference
 
@@ -97,15 +97,15 @@ Add to your `.babelrc`:
 
 ```js
 import {Sequelize, Model, DataTypes} from 'sequelize'
-import {Options, Attributes} from 'sequelize-decorators'
+import {options, attributes} from 'sequelize-decorators'
 
 const sequelize = new Sequelize(process.env.DB)
 
-@Options({
+@options({
     sequelize,
     tableName: 'users'
 })
-@Attributes({
+@attributes({
     username: {
         type: DataTypes.STRING,
         primaryKey: true
@@ -127,4 +127,4 @@ export class User extends Model {
 }
 ```
 
-The `@Options` decorator is required and must include the `sequelize` option (the connection to use).
+The `@options` decorator is required and must include the `sequelize` option (the connection to use).

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,14 @@ import 'reflect-metadata';
 
 const S_ATTRIBUTES = Symbol('attributes');
 
-export function Options(options: InitOptions) {
+export function options(options: InitOptions) {
     return function(model: typeof Model): void {
         const attributes: ModelAttributes = Reflect.getMetadata(S_ATTRIBUTES, model) || {};
         model.init(attributes, options);
     };
 }
 
-export function Attribute(options?: string | DataTypes.DataType | ModelAttributeColumnOptions) {
+export function attribute(options?: string | DataTypes.DataType | ModelAttributeColumnOptions) {
     return function(prototype: Object, name: string): void {
         const type = Reflect.getMetadata('design:type', prototype, name);
         if (!options && type) {
@@ -29,7 +29,7 @@ export function Attribute(options?: string | DataTypes.DataType | ModelAttribute
     };
 }
 
-export function Attributes(attributes: ModelAttributes) {
+export function attributes(attributes: ModelAttributes) {
     return function(model: typeof Model): void {
         Reflect.defineMetadata(S_ATTRIBUTES, attributes, model);
     };

--- a/src/test/babel.js
+++ b/src/test/babel.js
@@ -1,7 +1,7 @@
 
 import assert from 'assert';
 import {Sequelize, Model, DataTypes} from 'sequelize';
-import {Options, Attributes} from '../index';
+import {options, attributes} from '../index';
 import * as sinon from 'sinon';
 
 // Just a dummy
@@ -13,20 +13,20 @@ describe('Babel', () => {
         const stub = sinon.stub(Model, 'init');
 
         try {
-            @Options({sequelize})
-            @Attributes({username: Sequelize.STRING})
+            @options({sequelize})
+            @attributes({username: Sequelize.STRING})
             class User extends Model {} // eslint-disable-line no-unused-vars
 
             assert(stub.calledOnce);
 
-            const attributes = stub.args[0][0];
-            const options = stub.args[0][1];
+            const attributesArg = stub.args[0][0];
+            const optionsArg = stub.args[0][1];
 
-            assert.equal(typeof attributes, 'object');
-            assert.equal(attributes.username, DataTypes.STRING);
+            assert.equal(typeof attributesArg, 'object');
+            assert.equal(attributesArg.username, DataTypes.STRING);
 
-            assert.equal(typeof options, 'object');
-            assert.equal(options.sequelize, sequelize);
+            assert.equal(typeof optionsArg, 'object');
+            assert.equal(optionsArg.sequelize, sequelize);
 
         } finally {
 

--- a/src/test/typescript.ts
+++ b/src/test/typescript.ts
@@ -1,7 +1,7 @@
 
 import assert = require('assert');
 import {Sequelize, Model, DataTypes} from 'sequelize';
-import {Options, Attribute} from '../index';
+import {options, attribute} from '../index';
 import * as sinon from 'sinon';
 
 // Just a dummy
@@ -15,39 +15,39 @@ describe('TypeScript', () => {
 
         try {
 
-            @Options({sequelize})
+            @options({sequelize})
             class User extends Model {
 
-                @Attribute(DataTypes.STRING)
+                @attribute(DataTypes.STRING)
                 public username: string;
 
-                @Attribute()
+                @attribute()
                 public street: string;
 
-                @Attribute()
+                @attribute()
                 public loginCount: number;
 
-                @Attribute()
+                @attribute()
                 public lastLogin: Date;
 
-                @Attribute()
+                @attribute()
                 public passwordHash: Buffer;
             }
 
             assert(stub.calledOnce);
 
-            const attributes = stub.args[0][0];
-            const options = stub.args[0][1];
+            const attributesArg = stub.args[0][0];
+            const optionsArg = stub.args[0][1];
 
-            assert.equal(typeof attributes, 'object');
-            assert.equal(attributes.username, DataTypes.STRING);
-            assert.equal(attributes.street, DataTypes.STRING);
-            assert.equal(attributes.loginCount, DataTypes.INTEGER);
-            assert.equal(attributes.lastLogin, DataTypes.DATE);
-            assert.equal(attributes.passwordHash, DataTypes.BLOB);
+            assert.equal(typeof attributesArg, 'object');
+            assert.equal(attributesArg.username, DataTypes.STRING);
+            assert.equal(attributesArg.street, DataTypes.STRING);
+            assert.equal(attributesArg.loginCount, DataTypes.INTEGER);
+            assert.equal(attributesArg.lastLogin, DataTypes.DATE);
+            assert.equal(attributesArg.passwordHash, DataTypes.BLOB);
 
-            assert.equal(typeof options, 'object');
-            assert.equal(options.sequelize, sequelize);
+            assert.equal(typeof optionsArg, 'object');
+            assert.equal(optionsArg.sequelize, sequelize);
 
         } finally {
 


### PR DESCRIPTION
I am not sure what to do here, as there is no convention yet. Technically, a decorator is a plain function, and not a class. Especially the decorators that receive arguments are technically decorator _factories_.

The only really big use of decorators in Angular 2 currently, and they uppercase all decorators.
But examples from the decorator proposal always use lowercase, like `@enumerable` or `@readonly`.

Would like to hear some opinions!
